### PR TITLE
Check for isEmpty instead of count > 0

### DIFF
--- a/TallestTowersTests/TowerTests.swift
+++ b/TallestTowersTests/TowerTests.swift
@@ -24,6 +24,6 @@ class TowerInstanceTests: XCTestCase {
 
 class TowerStaticTests: XCTestCase {
   func testTallestTowersShouldNotBeEmpty() {
-    XCTAssert(Tower.tallestTowers.count > 0)
+    XCTAssert(!Tower.tallestTowers.isEmpty)
   }
 }


### PR DESCRIPTION
Hi there!

For this following test case, do you think it makes sense to check for isEmpty vs count > 0, so it is similar to the naming of the test? 